### PR TITLE
remove: group designation from chown

### DIFF
--- a/src/saml2aws/install.sh
+++ b/src/saml2aws/install.sh
@@ -63,10 +63,10 @@ if [ "$USERNAME" != "root" ]; then
     ln -s /usr/local/share/.aws/config /home/${USERNAME}/.aws/config
     ln -s /usr/local/share/.saml2aws /home/${USERNAME}/.saml2aws
     touch /home/${USERNAME}/.aws/credentials
-    chown -h "${USERNAME}":root /home/${USERNAME}/.aws/credentials
+    chown -h "${USERNAME}" /home/${USERNAME}/.aws/credentials
     chmod +w /home/${USERNAME}/.aws/credentials
     mkdir /home/${USERNAME}/.aws/cli
-    chown -R "${USERNAME}":root /home/${USERNAME}/.aws/cli
+    chown -R "${USERNAME}" /home/${USERNAME}/.aws/cli
 else
     mkdir /root/.aws
     ln -s /usr/local/share/.aws/config /root/.aws/config


### PR DESCRIPTION
I am not sure of the cause, but it is because the group is specified as root, which may result in a permission error.

```
2024-12-01 12:36:23 Container started
2024-12-01 12:36:24 chown: changing ownership of '/home/vscode/.aws/credentials': Operation not permitted
2024-12-01 12:36:24 chown: changing ownership of '/home/vscode/.aws/cli': Operation not permitted
```

Reported by @wezard706, thanks.